### PR TITLE
Add rtl8703as support (100% compatible), add support for getting mac-addresses from devicetree

### DIFF
--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -1167,9 +1167,13 @@ u8 key_2char2num(u8 hch, u8 lch)
 		return ((key_char2num(hch) << 4) | key_char2num(lch));
 }
 
-void rtw_macaddr_cfg(u8 *mac_addr)
+void rtw_macaddr_cfg(struct device *dev, u8 *mac_addr)
 {
 	u8 mac[ETH_ALEN];
+	struct device_node *np = dev->of_node;
+	const unsigned char *addr;
+	int len;
+
 	if (mac_addr == NULL)
 		return;
 
@@ -1188,15 +1192,21 @@ void rtw_macaddr_cfg(u8 *mac_addr)
 	     (mac[3] == 0xff) && (mac[4] == 0xff) && (mac[5] == 0xff)) ||
 	    ((mac[0] == 0x00) && (mac[1] == 0x00) && (mac[2] == 0x00) &&
 	     (mac[3] == 0x00) && (mac[4] == 0x00) && (mac[5] == 0x00))) {
-		mac[0] = 0x00;
-		mac[1] = 0xe0;
-		mac[2] = 0x4c;
-		mac[3] = 0x87;
-		mac[4] = 0x00;
-		mac[5] = 0x00;
-		/*  use default mac addresss */
-		memcpy(mac_addr, mac, ETH_ALEN);
-		DBG_871X("MAC Address from efuse error, assign default one !!!\n");
+	        if (np &&
+	            (addr = of_get_property(np, "local-mac-address", &len)) &&
+	            len == ETH_ALEN) {
+			memcpy(mac_addr, addr, ETH_ALEN);
+		} else {
+			mac[0] = 0x00;
+			mac[1] = 0xe0;
+			mac[2] = 0x4c;
+			mac[3] = 0x87;
+			mac[4] = 0x00;
+			mac[5] = 0x00;
+			/*  use default mac addresss */
+			memcpy(mac_addr, mac, ETH_ALEN);
+			DBG_871X("MAC Address from efuse error, assign default one !!!\n");
+		}
 	}
 
 	DBG_871X("rtw_macaddr_cfg MAC Address  = "MAC_FMT"\n", MAC_ARG(mac_addr));

--- a/hal/rtl8723b_hal_init.c
+++ b/hal/rtl8723b_hal_init.c
@@ -2662,7 +2662,10 @@ void Hal_EfuseParseBTCoexistInfo_8723B(
 			pHalData->ant_path = (tempval & BIT(6))?ODM_RF_PATH_B:ODM_RF_PATH_A;
 		} else {
 			pHalData->EEPROMBluetoothAntNum = Ant_x1;
-			pHalData->ant_path = ODM_RF_PATH_A;
+			if (pHalData->PackageType == PACKAGE_QFN68)
+				pHalData->ant_path = ODM_RF_PATH_B;
+			else
+				pHalData->ant_path = ODM_RF_PATH_A;
 		}
 	} else {
 		pHalData->EEPROMBluetoothCoexist = false;

--- a/hal/sdio_halinit.c
+++ b/hal/sdio_halinit.c
@@ -1335,10 +1335,10 @@ static void _ReadEfuseInfo8723BS(struct adapter *padapter)
 	/*  */
 	/*  Read Bluetooth co-exist and initialize */
 	/*  */
+	Hal_EfuseParsePackageType_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
 	Hal_EfuseParseBTCoexistInfo_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
 	Hal_EfuseParseChnlPlan_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
 	Hal_EfuseParseXtal_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
-	Hal_EfuseParsePackageType_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
 	Hal_EfuseParseThermalMeter_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
 	Hal_EfuseParseAntennaDiversity_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);
 	Hal_EfuseParseCustomerID_8723B(padapter, hwinfo, pEEPROM->bautoload_fail_flag);

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1335,7 +1335,7 @@ int rtw_check_network_type(unsigned char *rate, int ratelen, int channel);
 
 void rtw_get_bcn_info(struct wlan_network *pnetwork);
 
-void rtw_macaddr_cfg(u8 *mac_addr);
+void rtw_macaddr_cfg(struct device *dev, u8 *mac_addr);
 
 u16 rtw_mcs_rate(u8 rf_type, u8 bw_40MHz, u8 short_GI, unsigned char * MCS_rate);
 

--- a/os_dep/sdio_intf.c
+++ b/os_dep/sdio_intf.c
@@ -329,6 +329,7 @@ static struct adapter *rtw_sdio_if1_init(struct dvobj_priv *dvobj, const struct 
 	int status = _FAIL;
 	struct net_device *pnetdev;
 	struct adapter *padapter = NULL;
+	PSDIO_DATA psdio = &dvobj->intf_data;
 
 	if ((padapter = (struct adapter *)vzalloc(sizeof(*padapter))) == NULL) {
 		goto exit;
@@ -393,7 +394,7 @@ static struct adapter *rtw_sdio_if1_init(struct dvobj_priv *dvobj, const struct 
 
 	/* 3 8. get WLan MAC address */
 	/*  set mac addr */
-	rtw_macaddr_cfg(padapter->eeprompriv.mac_addr);
+	rtw_macaddr_cfg(&psdio->func->dev, padapter->eeprompriv.mac_addr);
 
 	rtw_hal_disable_interrupt(padapter);
 


### PR DESCRIPTION
Hi,

Here is a rebased version of my previous pull-req. This pull-req consists of 2 small patches which together allow usage of the rtl8723bs on (ARM) tablets with rtl8703as wifi controllers.

I found out the antenna-path thing by diffing the rtl8723bs and rtl8723bs_vq0 dirs here:
https://github.com/longsleep/linux-pine64/tree/pine64-hacks-1.2/drivers/net/wireless

I never got any response to my previous pull-req , it would be nice to get some response this time ...

Regards,

Hans
