### PR TITLE
os_dep: include <linux/signal.h>

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -44,6 +44,7 @@
 	#include <linux/kthread.h>
 	#include <linux/list.h>
 	#include <linux/vmalloc.h>
+	#include <linux/signal.h>
 
 /* 	#include <linux/ieee80211.h> */
         #include <net/ieee80211_radiotap.h>

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -45,6 +45,10 @@
 	#include <linux/list.h>
 	#include <linux/vmalloc.h>
 	#include <linux/signal.h>
+	#include <linux/version.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
+	#include <linux/sched/signal.h>
+#endif
 
 /* 	#include <linux/ieee80211.h> */
         #include <net/ieee80211_radiotap.h>


### PR DESCRIPTION
<linux/signal.h> is now not implicitly included in kernel.

Manually include it.

Signed-off-by: Icenowy Zheng <icenowy@aosc.xyz>